### PR TITLE
Add Unit Tests covering 100% of the supported alien options

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const alienDefaults = {
     advanced: {
         startAction: (object = undefined) => {},
         finalAction: (object = undefined) => {},
-        stepAction: (name = undefined) => {},
+        stepAction: (object = undefined, name = undefined) => {},
         allowUnsafeFinalization: true
     }
 }
@@ -76,7 +76,7 @@ export const ℿ = (builderArray, options) => {
             }
 
         }
-        stepAction(name)
+        stepAction(builderObject, name)
     }
 
     if(setObjects) {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const alienDefaults = {
 }
 
 export const ℿ = (builderArray, options) => {
-    const getValueOrDefault = (section, ident) => ( options && options[section] && (options[section][ident] !== null && options[section][ident] !== undefined ))
+    const getValueOrDefault = (section, ident) => ( options && options[section] && (options[section][ident] !== null && options[section][ident] !== undefined )) && options[section][ident]
         || alienDefaults[section][ident]
 
     const start = getValueOrDefault('advanced', 'startAction')

--- a/index.test.js
+++ b/index.test.js
@@ -71,3 +71,27 @@ describe('Alien Control properties', () => {
         expect(setNameUnsetEmail.email).not.toBeDefined()
     })
 })
+
+describe('Alien Advanced properties', () => {
+  test('startAction properly works', () => {
+    let setNameUnsetEmail = ℿ(['name', 'email'], {advanced: {startAction: (builder) => builder.SEE_IF_I_EXIST = 'yes'}}).setName('John')
+
+      expect(setNameUnsetEmail.SEE_IF_I_EXIST).toBe('yes')
+  })
+
+    test('stepAction properly works', () => {
+        let setNameSetEmail = ℿ(['name', 'email'], {advanced: {stepAction: (builder, name) => builder.count = (builder.count || 0) + 1}})
+            .setName('John')
+            .setEmail('john@email.com')
+
+        expect(setNameSetEmail.count).toBe(2)
+    })
+
+    test('finalAction properly works', () => {
+      let setNameUnsetEmail = ℿ(['name', 'email'], {advanced: {finalAction: builder => builder.email = 'john@email.com'}})
+          .setName('John')
+          .finalize()
+
+        expect(setNameUnsetEmail.email).toBe('john@email.com')
+    })
+})

--- a/index.test.js
+++ b/index.test.js
@@ -41,7 +41,33 @@ describe('Alien Control properties', () => {
     test('nameTransformer properly works', () => {
       let setNameUnsetEmail = ℿ(['name', 'email'], {control: { nameTransformer: (name => "_" + name)}})
         setNameUnsetEmail.setName('John')
+
         expect(setNameUnsetEmail._name).toBe('John')
         expect(setNameUnsetEmail._email).toBeUndefined()
+    })
+
+    test('setterTransformer properly works', () => {
+        let setNameUnsetEmail = ℿ(['name', 'email'], {control: {setterTransformer: (name => "_" + name)}})
+        setNameUnsetEmail._name('John')
+
+        expect(setNameUnsetEmail.name).toBe('John')
+        expect(setNameUnsetEmail.email).toBeUndefined()
+    })
+
+    test('setObjects properly works', () => {
+        let setNameSetEmail = ℿ(['name', 'email'], {control: {setObjects: true}}).set({name: 'John', email: "john@email.com"})
+
+        expect(setNameSetEmail.name).toBe('John')
+        expect(setNameSetEmail.email).toBe('john@email.com')
+    })
+
+    test('createBlankProperty properly works', () => {
+        let blankSetNameUnsetEmail = ℿ(['name', 'email'], {control: {createBlankProperty: true}})
+        let setNameUnsetEmail = ℿ(['name', 'email'], {control: {createBlankProperty: false}})
+
+        blankSetNameUnsetEmail.setName('John')
+
+        expect(blankSetNameUnsetEmail.email).toBeUndefined()
+        expect(setNameUnsetEmail.email).not.toBeDefined()
     })
 })

--- a/index.test.js
+++ b/index.test.js
@@ -24,4 +24,15 @@ describe('Alien finalizers', () => {
       expect(setNameUnsetEmail.name).toBe('John')
       expect(setNameUnsetEmail).not.toHaveProperty('email')
   })
+    test('RemoveSetters properly works', () => {
+      let setNameUnsetEmail = ℿ(['name', 'email'], {finalization: {removeSetters: true}})
+        setNameUnsetEmail.setName('John')
+        setNameUnsetEmail.finalize()
+
+        expect(setNameUnsetEmail.name).toBe('John')
+
+        expect(setNameUnsetEmail.email).toBeUndefined()
+        expect(setNameUnsetEmail.setEmail).toBeUndefined()
+        expect(setNameUnsetEmail.setName).toBeUndefined()
+    })
 })

--- a/index.test.js
+++ b/index.test.js
@@ -36,3 +36,12 @@ describe('Alien finalizers', () => {
         expect(setNameUnsetEmail.setName).toBeUndefined()
     })
 })
+
+describe('Alien Control properties', () => {
+    test('nameTransformer properly works', () => {
+      let setNameUnsetEmail = ℿ(['name', 'email'], {control: { nameTransformer: (name => "_" + name)}})
+        setNameUnsetEmail.setName('John')
+        expect(setNameUnsetEmail._name).toBe('John')
+        expect(setNameUnsetEmail._email).toBeUndefined()
+    })
+})


### PR DESCRIPTION
This pull request fixes a bug, adds a feature, and adds a whole heap of unit tests.

# The Feature
`stepActions` can now modify the `builder` in addition to seeing the name

# The Bug
Non-boolean options (i.e any `advanced` option) were not being read correctly, and would crash alien. 

# The tests
These tests cover 100% of alien, expect for combinations of options and the two unsupported options `{schema: false}` and `allowUnsafeFinalization: true`