### PR TITLE
Minimization: Reduce the size of logic branches based on schema

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -92,6 +92,6 @@ describe('Alien Advanced properties', () => {
           .setName('John')
           .finalize()
 
-        expect(setNameUnsetEmail.email).toBe('john@email.com')
+        expect(setNameUnsetEmail.email).toBe('john@email.com'       )
     })
 })


### PR DESCRIPTION
Adds the first step in the effort to minimize the ES6 code.

There were many points around the project where there was a branch in decision logic, based on if your builder had a `.schema` property.

This abstracted out the concept of that decision point into a helper method, and filtered the rest of the features through that. This produces 27% less code.