### PR TITLE
Add the ability to provide default values to alien calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,11 +156,16 @@ export const ℿ = (builderArray, alienOptions) => {
 
     // Step 1: Iterate over the builder array
     for (const parameter of builderArray) {
-        const name = nameTransformer(parameter)
-        const setterName = setterTransformer(parameter)
+        const currentName = typeof parameter === 'object' ? first(Object.keys(parameter)) : parameter
+        const name = nameTransformer(currentName)
+        const setterName = setterTransformer(currentName)
 
         if (createBlankProperty) {
             builderObject[name] = undefined
+        }
+
+        if(typeof parameter === 'object') {
+            builderObject[name] = parameter[currentName]
         }
 
         builderObject[[setterName]] = (value) => {

--- a/index.test.js
+++ b/index.test.js
@@ -120,3 +120,10 @@ describe('Alien fast options', () => {
         expect(underscoreEmail._email).toBe('john')
     })
 })
+
+describe('Alien default values', () => {
+    test('Alien default values', () => {
+      let setNameUnsetEmail = ℿ([{name: 'John'}, 'email'])
+        expect(setNameUnsetEmail.name).toBe('John')
+    })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "alien",
-  "version": "0.1.0",
+  "name": "alien-cascade",
+  "version": "0.1.3",
   "description": "Create a fully configurable fluent interface to your DTO",
   "main": "index.js",
   "repository": "https://www.github.com/natepisarski/alien",


### PR DESCRIPTION
You can now supply default values to alien, via `ℿ(['prop1', {prop2: 'value'}])`